### PR TITLE
Autodetect availability of C extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ if len(argv) > 1 and argv[1] in custom_args:
 impl = python_implementation()
 
 if custom_arg == None:
-    if impl == "PyPy":
+    if impl == "PyPy" or not src_path.exists():
         custom_arg = "py"
     else:
         custom_arg = "c"


### PR DESCRIPTION
This improves default behavior of setup.py in sense that py version of frozendict is used for python versions which do not have C extension available yet. This would probably reduce amount of issues similar to [1-4] in future.

[1] https://github.com/Marco-Sulla/python-frozendict/issues/68
[2] https://github.com/Marco-Sulla/python-frozendict/issues/67
[3] https://github.com/Marco-Sulla/python-frozendict/issues/65
[4] https://github.com/Marco-Sulla/python-frozendict/issues/58