### PR TITLE
Avoid storing empty singleton on class itself in python implementation

### DIFF
--- a/src/frozendict/core.py
+++ b/src/frozendict/core.py
@@ -7,6 +7,8 @@ def immutable(self, *args, **kwargs):
     
     raise AttributeError(f"'{self.__class__.__name__}' object is read-only")
 
+_empty_frozendict_singleton = None
+
 class frozendict(dict):
     r"""
     A simple immutable dictionary.
@@ -50,11 +52,12 @@ class frozendict(dict):
             # empty singleton - start
             
             if self.__class__ == frozendict and not len(self):
-                try:
-                    self = cls.empty
+                global _empty_frozendict_singleton
+                if _empty_frozendict_singleton is None:
+                    _empty_frozendict_singleton = self
+                else:
+                    self = _empty_frozendict_singleton
                     continue_creation = False
-                except AttributeError:
-                    cls.empty = self
             
             # empty singleton - end
             

--- a/src/frozendict/core.py
+++ b/src/frozendict/core.py
@@ -7,7 +7,7 @@ def immutable(self, *args, **kwargs):
     
     raise AttributeError(f"'{self.__class__.__name__}' object is read-only")
 
-_empty_frozendict_singleton = None
+_empty_frozendict = None
 
 class frozendict(dict):
     r"""
@@ -52,11 +52,12 @@ class frozendict(dict):
             # empty singleton - start
             
             if self.__class__ == frozendict and not len(self):
-                global _empty_frozendict_singleton
-                if _empty_frozendict_singleton is None:
-                    _empty_frozendict_singleton = self
+                global _empty_frozendict
+
+                if _empty_frozendict is None:
+                    _empty_frozendict = self
                 else:
-                    self = _empty_frozendict_singleton
+                    self = _empty_frozendict
                     continue_creation = False
             
             # empty singleton - end


### PR DESCRIPTION
```python
import dill
import frozendict


def test_foo():
    # this will work
    dill.dumps(frozendict.frozendict(a=1))

    # construct the first empty frozendict
    frozendict.frozendict()

    # this will blow up with:
    # dill._dill.PicklingWarning: Cannot locate reference to <class 'frozendict.core.frozendict'>.
    dill.dumps(frozendict.frozendict(a=1))
```

There are a few things going on here, but this solves the immediate problem that anyone anywhere constructing an empty frozendict when using the python implementation will change the behavior for subsequent calls to `dill.dumps`.

The larger issue, that I don't really know how to solve satisfactorily, is that dill thinks it needs to pickle the class itself rather than a reference to it.  I will open an issue with more details about that.

See: #87 #88