### PR TITLE
Prefer forward conversion if registered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Pipfile
 test/core.*
 .eggs/
 .idea/
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ Pipfile
 test/core.*
 .eggs/
 .idea/
-/.vs
+.vs/

--- a/src/frozendict/cool.py
+++ b/src/frozendict/cool.py
@@ -287,10 +287,14 @@ def deepfreeze(
             custom_inverse_converters = custom_inverse_converters
         )
     
-    if frozen_type:
-        return type_o(o)
-    
-    return freeze_conversion_map[base_type_o](o)
+    try:
+        freeze = freeze_conversion_map[base_type_o]
+    except KeyError:
+        if frozen_type:
+            freeze = type_o
+        else:
+            raise
+    return freeze(o)
 
 
 __all__ = (

--- a/src/frozendict/cool.py
+++ b/src/frozendict/cool.py
@@ -294,6 +294,7 @@ def deepfreeze(
             freeze = type_o
         else:
             raise
+    
     return freeze(o)
 
 


### PR DESCRIPTION
When a forward conversion is registered to getFreezeConversionMap(), that explicit conversion is now preferred over the (implicit) inverse of a (backward) conversion registered to getFreezeConversionInverseMap(). This behavior is consistent with the preexisting preference for explicit forward conversion of certain simple types (_freeze_types_plain) and non-iterables and strings (i.e., excluded by isIterableNotString()).

The modified behavior can be seen in the example below:
```
import frozendict
import types

dic = {"a": "A"}
prox = types.MappingProxyType(dic)

frozendict.register(types.MappingProxyType, frozendict.frozendict)

frozen = frozendict.deepfreeze(prox)
isinstance(frozen, frozendict.frozendict)  # Now True, was False
isinstance(frozen, types.MappingProxyType)  # Was True, now False
```

As a practical use case, I'm currently working on a project in which I'd like to use deepfreeze() to ensure that a nested mappingproxy is hashable.