### PR TITLE
`deepfrozen` should not modify original object

### DIFF
--- a/src/frozendict/cool.py
+++ b/src/frozendict/cool.py
@@ -280,8 +280,8 @@ def deepfreeze(
     
     o_copy = copy(o)
     
-    for k, v in getItems(o)(o_copy):
-        o[k] = deepfreeze(
+    for k, v in getItems(o_copy)(o_copy):
+        o_copy[k] = deepfreeze(
             v,
             custom_converters = custom_converters,
             custom_inverse_converters = custom_inverse_converters
@@ -295,7 +295,7 @@ def deepfreeze(
         else:
             raise
     
-    return freeze(o)
+    return freeze(o_copy)
 
 
 __all__ = (

--- a/test/test_freeze.py
+++ b/test/test_freeze.py
@@ -183,19 +183,12 @@ def test_prefer_forward():
         FrozenSeqB
         )
 
-def test_nested_deepfreeze():
+def test_original_immutate():
     unfrozen = {
         "int": 1,
         "nested": {"int": 1},
     }
 
     frozen = cool.deepfreeze(unfrozen)
-    assert type(frozen) is frozendict
-    assert type(frozen["int"]) is int
-    assert type(frozen["nested"]) is frozendict
-    assert type(frozen["nested"]["int"]) is int
-
-    assert type(unfrozen) is dict
-    assert type(unfrozen["int"]) is int
+    
     assert type(unfrozen["nested"]) is dict
-    assert type(unfrozen["nested"]["int"]) is int

--- a/test/test_freeze.py
+++ b/test/test_freeze.py
@@ -182,3 +182,20 @@ def test_prefer_forward():
             )[0],
         FrozenSeqB
         )
+
+def test_nested_deepfreeze():
+    unfrozen = {
+        "int": 1,
+        "nested": {"int": 1},
+    }
+
+    frozen = cool.deepfreeze(unfrozen)
+    assert type(frozen) is frozendict
+    assert type(frozen["int"]) is int
+    assert type(frozen["nested"]) is frozendict
+    assert type(frozen["nested"]["int"]) is int
+
+    assert type(unfrozen) is dict
+    assert type(unfrozen["int"]) is int
+    assert type(unfrozen["nested"]) is dict
+    assert type(unfrozen["nested"]["int"]) is int


### PR DESCRIPTION
Adds a test and corrects the deepfreeze implementation for nested `dict`.

Resovles #96 