### PR TITLE
Fix C extension build for unsupported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ mix_c_py_error = ValueError(
 )
 
 if custom_arg is None:
-    if impl == "PyPy":
+    if impl == "PyPy" or not c_src_path.exists():
         custom_arg = "py"
     else:
         custom_arg = "py" if pure_py else "c"


### PR DESCRIPTION
When the C source directory does not exist for the running Python version (e.g. 3.11+), the build silently skips compilation due to optional=True but still declares ext_modules, producing a wheel tagged as platform-specific (cp312-cp312-linux_x86_64) with no native code inside.

Check whether c_src/<version>/ exists before declaring the C extension. If it does not, fall back to pure-Python mode so the wheel is correctly tagged as py3-none-any.